### PR TITLE
feat(api-client) HttpOptions usage of reportProgress & withCredentials

### DIFF
--- a/templates/ngx-service.mustache
+++ b/templates/ngx-service.mustache
@@ -31,7 +31,9 @@ export class APIClient {
 
     this.options = {
       headers: options && options.headers ? options.headers : new HttpHeaders(),
-      params: options && options.params ? options.params : new HttpParams()
+      params: options && options.params ? options.params : new HttpParams(),
+      ...(options && options.reportProgress ? { reportProgress: options.reportProgress } : {}),
+      ...(options && options.withCredentials ? { withCredentials: options.withCredentials } : {})
     };
   }
 

--- a/tests/esquare/api/api-client.service.ts
+++ b/tests/esquare/api/api-client.service.ts
@@ -29,7 +29,9 @@ export class APIClient {
 
     this.options = {
       headers: options && options.headers ? options.headers : new HttpHeaders(),
-      params: options && options.params ? options.params : new HttpParams()
+      params: options && options.params ? options.params : new HttpParams(),
+      ...(options && options.reportProgress ? { reportProgress: options.reportProgress } : {}),
+      ...(options && options.withCredentials ? { withCredentials: options.withCredentials } : {})
     };
   }
 

--- a/tests/gcloud-firestore/api/api-client.service.ts
+++ b/tests/gcloud-firestore/api/api-client.service.ts
@@ -29,7 +29,9 @@ export class APIClient {
 
     this.options = {
       headers: options && options.headers ? options.headers : new HttpHeaders(),
-      params: options && options.params ? options.params : new HttpParams()
+      params: options && options.params ? options.params : new HttpParams(),
+      ...(options && options.reportProgress ? { reportProgress: options.reportProgress } : {}),
+      ...(options && options.withCredentials ? { withCredentials: options.withCredentials } : {})
     };
   }
 

--- a/tests/github/api/api-client.service.ts
+++ b/tests/github/api/api-client.service.ts
@@ -29,7 +29,9 @@ export class APIClient {
 
     this.options = {
       headers: options && options.headers ? options.headers : new HttpHeaders(),
-      params: options && options.params ? options.params : new HttpParams()
+      params: options && options.params ? options.params : new HttpParams(),
+      ...(options && options.reportProgress ? { reportProgress: options.reportProgress } : {}),
+      ...(options && options.withCredentials ? { withCredentials: options.withCredentials } : {})
     };
   }
 


### PR DESCRIPTION
* Fixes #45
reportProgress & withCredentials are set from constructor now if available.

* automated tests for #45

closes #issue
